### PR TITLE
Form for exercise now gives an error when in invalid input is passed

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -10,6 +10,7 @@ class ExercisesController < ApplicationController
     if @exercise.save
       redirect_to @workout
     else
+      @workout.reload
       render 'workouts/show', :status => :unprocessable_entity
     end
   end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -6,8 +6,12 @@ class ExercisesController < ApplicationController
 
   def create
     @workout = Workout.find(params[:workout_id])
-    @workout.exercises.create(exercise_params)
-    redirect_to @workout
+    @exercise = @workout.exercises.create(exercise_params)
+    if @exercise.save
+      redirect_to @workout
+    else
+      render 'workouts/show', :status => :unprocessable_entity
+    end
   end
 
   def destroy

--- a/app/views/workouts/show.html.erb
+++ b/app/views/workouts/show.html.erb
@@ -25,17 +25,18 @@
           </td>
           <% end %>
         <% end %>
-        <%= form_for(@exercise, :url => workout_exercises_path(@workout), html: {class: 'form-horizontal'}) do |f| %>
+
+        <%= simple_form_for(@exercise, :url => workout_exercises_path(@workout), html: {class: 'form-horizontal'}) do |f| %>
           <div class="table-responsive">
             <tr>
               <td>
-                <%= f.text_field :name, as: :text, class: "form-control", rows: 1, placeholder: "Name" %>
+                <%= f.input :name,  placeholder: "Name", label:  false %>
               </td>
               <td>
-                <%= f.number_field :reps, as: :integer, class: "form-control", rows: 1, :collection => 1..12, placeholder: "Reps" %>
+                <%= f.input :reps, placeholder: "Reps", label: false %>
               </td>
               <td>
-                <%= f.text_field :note, as: :text, class: "form-control", rows: 1, placeholder: "Notes" %>
+                <%= f.input :note, placeholder: "Notes", label: false %>
                 <td>
                   <div class="actions form-group center-block">
                     <div class="col-sm-offset-2 col-sm-10 center-block">

--- a/app/views/workouts/show.html.erb
+++ b/app/views/workouts/show.html.erb
@@ -1,8 +1,8 @@
 <div class="table-container col-xs-12">
   <h3><%= "#{@workout.title}" " - #{@workout.created_at.strftime("%b %e, %Y %l:%M %p")}"%></h3>
   <div class ="btn-toolbar">
-    <%= link_to "copy this workout", workout_copy_path(params[:id]), :class => 'btn btn-primary' %>
-    <%= link_to "delete this workout", workout_path(params[:id]), :method => :delete, :data => { :confirm => 'Are you sure you want to delete this?' }, :class => 'btn btn-danger' %>
+    <%= link_to "copy this workout", workout_copy_path(@workout), :class => 'btn btn-primary' %>
+    <%= link_to "delete this workout", workout_path(@workout), :method => :delete, :data => { :confirm => 'Are you sure you want to delete this?' }, :class => 'btn btn-danger' %>
     <%= link_to "edit this workout", edit_workout_path(@workout), :class => 'btn btn-success' %>
   </div>
   <div class="table-responsive">
@@ -14,12 +14,12 @@
         <th class="col-md-1 col-xs-1 text-center">destroy</th>
       </tr>
 
-      <% @exercises.each do |exercise| %>
+      <% @workout.exercises.each do |exercise| %>
         <tr>
           <td><%= exercise.name %></td>
           <td class="text-center"><%= exercise.reps %><br></td>
           <td><%= exercise.note%><br></td>
-          <td class="col-xs-1 text-center"><%= link_to workout_exercise_path(@workout, exercise), method: :delete,
+          <td class="col-xs-1 text-center"><%= link_to [@workout, exercise], method: :delete,
             data: { confirm: "You sure?" } do%>
             <span class="glyphicon glyphicon-remove"></span>
           </td>

--- a/spec/controllers/exercise_controller_spec.rb
+++ b/spec/controllers/exercise_controller_spec.rb
@@ -17,12 +17,14 @@ RSpec.describe ExercisesController, type: :controller do
   context "User leaves name field blank" do
     it "does not save a new exercise object" do
       expect { post :create, params: {workout_id: @workout, exercise: {name: '', reps: 12 } } }.to change( Exercise, :count).by(0)
+      expect(response).to have_http_status(422)
     end
   end
 
   context "User inputs 0 in reps" do
     it "does not save a new exercise object" do
       expect { post :create, params: { workout_id: @workout, exercise: {name: 'Chest', reps: 0 } } }.to change( Exercise, :count).by(0)
+      expect(response).to have_http_status(422)
     end
   end
 end


### PR DESCRIPTION
I added an unprocessable_entity error to the exercise create method so that invalid errors can't be passed through. This is the reason why I changed the form for exercise to simple_form. I also had to change the way that rails searched for workout from 'params[:id]' to '@workout' since it was giving errors whenever the page would be redirected for the unprocessable entity error. I also changed the exercise loop from '@exercises' to '@workout.exercises'
![screen shot 2016-10-30 at 8 23 33 pm](https://cloud.githubusercontent.com/assets/13066920/19841239/befa7b4c-9ede-11e6-8fc3-dc31ee4cae65.png)
